### PR TITLE
Yank the gist url to @+ even if -xterm_clipboard

### DIFF
--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -891,10 +891,10 @@ function! gist#Gist(count, bang, line1, line2, ...) abort
         endif
         if exists('g:gist_clip_command')
           call system(g:gist_clip_command, url)
-        elseif has('unix') && !has('xterm_clipboard')
-          let @" = url
-        else
+        elseif has('clipboard')
           let @+ = url
+        else
+          let @" = url
         endif
       endif
     endif


### PR DESCRIPTION
This yanks the URL to the expected register in versions of Vim that have
the +clipboard feature but not +xterm_clipboard (such as MacVim).

Fixes #187.