### PR TITLE
fix open_browser

### DIFF
--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -99,13 +99,17 @@ function! s:open_browser(url) abort
     return
   endif
   if cmd =~# '^!'
-    let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
+    let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
     silent! exec cmd
   elseif cmd =~# '^:[A-Z]'
     let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
     exec cmd
   else
-    let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
+    if has("win32") || has("win64")
+      let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
+    else
+      let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
+    endif
     call system(cmd)
   endif
 endfunction

--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -98,6 +98,14 @@ function! s:open_browser(url) abort
     echo a:url
     return
   endif
+  if exists('+shellslash')
+    let old_ssl = &shellslash
+    if fnamemodify(&shell, ':t') == 'cmd.exe'
+      set noshellslash
+    else
+      set shellslash
+    endif
+  endif
   if cmd =~# '^!'
     let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
     silent! exec cmd
@@ -105,12 +113,11 @@ function! s:open_browser(url) abort
     let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
     exec cmd
   else
-    if has("win32") || has("win64")
-      let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
-    else
-      let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
-    endif
+    let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
     call system(cmd)
+  endif
+  if exists('old_ssl')
+    let &shellslash = old_ssl
   endif
 endfunction
 

--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -99,13 +99,13 @@ function! s:open_browser(url) abort
     return
   endif
   if cmd =~# '^!'
-    let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
+    let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
     silent! exec cmd
   elseif cmd =~# '^:[A-Z]'
     let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
     exec cmd
   else
-    let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
+    let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
     call system(cmd)
   endif
 endfunction


### PR DESCRIPTION
fix open_browser.
When shellescape(a:url) is used to substitute, it will bring a problem that the url was added with ''(single quotation marks) in https://gist.github.com/xxx, which will cause the browser use something like **%27https//gist.github.com/xxx'** to open a website.