### PR TITLE
Added some actions (gist copy & gist paste into working buffer) and enhanced the listing layout. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
+### My modifications
+
+- New mappings on the gist-listing buffer:
+    - Both `o` or `Enter` open the gist file in a new buffer, and close the
+      gist-vim listing one.
+    - `b` opens the gist file in a browser; this is necessary because 
+      `Shift-Enter` (as was originally) only works for GUI vim.
+    - `y` copies the contents of the selected gist to the clipboard, and
+      closes the gist-vim buffer.
+    - `p` pastes the contents of the selected gist to the buffer from where
+      gist-vim was called, and closes the gist-vim buffer.
+    - Hitting `Escape` or `Tab` at the gist-vim buffer closes it.
+- Gist listing has fixed-length columns now, more amenable to eye inspection. 
+  Every line on the gist-listing buffer contains the gist id, name and
+  description, in that order. Columns are now padded and truncated to offer a
+  faster browsing, in the following way:
+  - The gist id string is fixed at 32 characters.
+  - The length (in characters) of the name of the gist is fixed and
+    can be set by the user using, for example:
+
+    `let g:gistvim_namelength = 20`
+
+    The default value for `gistvim_namelength` is 30. If the gist (file)name 
+    exceeds that length, it is truncated to the specified length.
+  - Finally, the gist description is truncated in length to fit the remaining 
+    of the line, avoiding wrapped lines that mess up the table layout.
+  - Note that the gist listing buffer now does not show the field 'code' 
+    (not sure what that did in the first place).
+
+- Now the listing is complete (no need to select 'more' to see the following
+  gists on the list), in this way the user can later perform a search (using vim's `/`,
+  for instance) for the sought gist by name, description, etc. 
+- The first line on the gist-listing states the number of gists listed and the
+  user whose gists are being listed.
+- The height of the gist-listing buffer is now determined in the following way.
+  If the number of gists listed equals or exceeds 10, then the height is fixed at 10. If
+  it is smaller than 10, then the height is adjusted so that there are no empty
+  lines displayed on the buffer. Note: right now this value (10) is fixed; I'm
+  going to change it to a global plugin variable that defaults to 10. 
+
 ### Gist.vim
 
 This is a vimscript for creating gists (http://gist.github.com).

--- a/doc/gist-vim.txt
+++ b/doc/gist-vim.txt
@@ -116,7 +116,21 @@ USAGE                                                 *:Gist* *gist-vim-usage*
 >
     :Gist -ls
     :Gist --liststar
-<
+
+- While the gist list is visible, the following mappings apply:
+
+  - 'o' or 'Enter' will open the selected gist file in a new buffer
+    and close the gist-vim listing split.
+  - 'b' will open the selected gist file in a browser. If you are in
+    GUI vim you can also achieve this by pressing 'Shift-Enter'.
+  - 'y' will copy the contents of the selected gist to the clipboard,
+    and close the gist-vim listing split.
+  - 'p' will (copy and) paste the contents of the selected gist to the
+    buffer from which gist-vim was called, and close the gist-vim 
+    listing split.
+  - 'Esc' will close the gist-vim listing split without performing any
+    further action.
+
 - Open the gist on browser after you post or update it.
 >
     :Gist -b
@@ -201,7 +215,19 @@ If you want to update a gist, embed >
 in your local file, then call >
 
     :Gist
->
+
+The gist-vim listing split lists gists ids, names (filenames) as well as
+their description. This is done following a table layout, with fixed space
+for each column. For offering quick browsing, gist-vim will truncate all
+output exceeding the available horizontal space, assuring that every gist
+listed only takes one line on the table. Although the gist id field width is
+fixed internally, the user can define the length of the (file)name field on
+the gist-vim listing. This can be done by the following declaration:
+
+    let g:gist_namelength = 20
+
+Note that the default value for gist_namelength is 30. Again, if the gist
+(file)name exceeds the specified number of characters, it will be truncated.
 
 If you want to update a gist when only |:w!|: >
 


### PR DESCRIPTION
While on the gist-vim listing split, the following mappings are now working:
- Both 'o' or 'Enter' open the gist file in a new buffer, and close the gist-vim listing one.
- 'b' opens the gist file in a browser; this is necessary because Shift-Enter (as was originally) only works for GUI vim.
- 'y' copies the contents of the selected gist to the clipboard, and closes the gist-vim buffer.
- 'p' pastes the contents of the selected gist to the buffer from where gist-vim was called, and closes the gist-vim buffer.
- Hitting Escape at the gist-vim buffer closes it.

Extra stuff:

- Gist listing has fixed-length columns now, more amenable to eye inspection. Every line on the gist-listing buffer contains the gist id, name and description, in that order. Columns are now padded and truncated to offer a faster browsing, in the following way:

- The gist id string is fixed at 32 characters.
- The length (in characters) of the name of the gist is fixed and can be set by the user using, for example:

    let g:gist_namelength = 20

- The default value for gist_namelength is 30. If the gist (file)name exceeds that length, it is truncated to the specified length.

- Finally, the gist description is truncated in length to fit the remaining of the line, avoiding wrapped lines that mess up the table layout.
- Note that the gist listing buffer now does not show the field 'code' (not sure what that did in the first place).
- Now the listing is complete (no need to select 'more' to see the following gists on the list), in this way the user can later perform a search (using vim's /, for instance) for the sought gist by name, description, etc.

- The first line on the gist-listing states the number of gists listed and the user whose gists are being listed.
- The height of the gist-listing buffer is now determined in the following way. If the number of gists listed equals or exceeds 10, then the height is fixed at 10. If it is smaller than 10, then the height is adjusted so that there are no empty lines displayed on the buffer. 

All this information has been added (with better phrasing) to the documentation.