### PR TITLE
profile management

### DIFF
--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -68,8 +68,8 @@ function! s:set_default_api_url()
   endif
 endfunction
 
-function! gist#select_profile(...)
-  let profile_name = a:0 ? a:1 : ''
+function! gist#select_profile(...) abort
+  let profile_name = a:0 ? a:1 : get(g:, 'gist_default_profile', '')
   let profile = get(s:gist_profiles, profile_name, [])
   if len(profile) == 2
     let [g:gist_api_url, g:github_user] = profile
@@ -817,10 +817,7 @@ function! gist#Gist(count, bang, line1, line2, ...) abort
       help :Gist
       return
     elseif arg =~# '^\(--profile\|-f\)'
-      if a:0 >= 2
-          call s:select_profile(a:2)
-      endif
-      return
+      call call('gist#select_profile', a:000[1:])
     elseif arg =~# '^\(-g\|--git\)$\C' && gistidbuf !=# '' && g:gist_api_url ==# 'https://api.github.com/' && has_key(b:, 'gist') && has_key(b:gist, 'id')
       echo printf('git clone git@github.com:%s', b:gist['id'])
       return

--- a/doc/gist-vim.txt
+++ b/doc/gist-vim.txt
@@ -15,6 +15,10 @@ For the latest version please see https://github.com/mattn/gist-vim.
 ==============================================================================
 USAGE                                                 *:Gist* *gist-vim-usage*
 
+- Select profile (see also |gist-vim-setup|) >
+
+    :Gist --profile [profilename]
+>
 - Post current buffer to gist, using default privacy option. >
 
     :Gist
@@ -293,10 +297,55 @@ REQUIREMENTS                                           *gist-vim-requirements*
   - and, if you want to use your git profile, the git command-line client.
 
 ==============================================================================
-SETUP                                                       *gist-vim-setup*
+SETUP                                                         *gist-vim-setup*
 
-This plugin uses GitHub API v3. The authentication value is stored in `~/.gist-vim`.
-gist-vim provides two ways to authenticate against the GitHub APIs.
+This plugin uses GitHub API v3. gist-vim provides two ways to authenticate
+against the GitHub APIs.
+
+                                                      *gist-vim-setup-profile*
+Method 1~
+
+You define the following variables
+>
+    let g:gist_profiles = {
+        \ 'github'     : ['', 'username'],
+        \ 'enterprise' : ['https://mycompany.com/api/v3', 'employeeid']
+    }
+
+    let g:gist_token_dir = '~/.config/gist-vim/'   (default value)
+
+    let g:gist_default_profile = 'enterprise'      (no default value)
+<
+and use
+>
+    :Gist --profile [profilename]
+<
+to select one profile. If `profilename` is not given, it fallbacks to
+`g:gist_default_profile` if it is defined. Otherwise, |gist-vim-setup-old| will
+be used. `:Gist --profile` is implicitly called when the script is autoloaded.
+
+Each profile defines the github api url and the login
+username. If the api url is `''`, it defaults to ` 'https://api.github.com/'`
+
+Then, gist.vim will ask for your password to create an authorization when you
+first use it.  The password is not stored and only the OAuth access token will
+be kept for later use. The token will be stored at
+>
+    g:gist_token_dir/profilename
+<
+You can revoke the token at any time from the list of
+"Authorized applications" on GitHub's "Account Settings" page.
+(https://github.com/settings/applications)
+
+If the profile is not correctly defined, for example, key does not exists or
+the list does not contain two elements, `:Gist --profile [profilename]` will
+fallback to the |gist-vim-setup-old| method.
+
+
+                                                      *gist-vim-setup-old*
+Method 2~
+
+This method does not allow you to have more than one profile.
 
 First, you need to set your GitHub username in global git config:
 >
@@ -304,8 +353,8 @@ First, you need to set your GitHub username in global git config:
 <
 Then, gist.vim will ask for your password to create an authorization when you
 first use it.  The password is not stored and only the OAuth access token will
-be kept for later use.  You can revoke the token at any time from the list of
-"Authorized applications" on GitHub's "Account Settings" page.
+be kept at `~/.gist-vim` for later use. You can revoke the token at any time
+from the list of "Authorized applications" on GitHub's "Account Settings" page.
 (https://github.com/settings/applications)
 
 If you have two-factor authentication enabled on GitHub, you'll see the message

--- a/plugin/gist.vim
+++ b/plugin/gist.vim
@@ -19,5 +19,6 @@ function! s:CompleteArgs(arg_lead,cmdline,cursor_pos)
 endfunction
 
 command! -nargs=? -range=% -bang -complete=customlist,s:CompleteArgs Gist :call gist#Gist(<count>, "<bang>", <line1>, <line2>, <f-args>)
+command! -nargs=? -complete=customlist,gist#list_profiles GistProfile call gist#select_profile(<q-args>)
 
 " vim:set et:


### PR DESCRIPTION
These commits introduce a new setup method which can handle more than one github accounts hosted by different github api url. The new method will have no effect for existing users unless they explicitly set some global variables (listed below, see `:help gist-vim-setup-profile` for details)

    let g:gist_profiles = {
        \ 'github'     : ['', 'username'],
        \ 'enterprise' : ['https://mycompany.com/api/v3', 'employeeid']
    }

    let g:gist_token_dir = '~/.config/gist-vim/'   (default value)

    let g:gist_default_profile = 'enterprise'      (no default value)

Two equivalent commands are introduced to switch between profiles. The second one has `completefunc` defined

      :Gist --profile [profilename]
      :GistProfile [profilename]

Any comment is appreciated.
    