### PR TITLE
addon-info.json: create the file to satisfy VAM

### DIFF
--- a/addon-info.json
+++ b/addon-info.json
@@ -1,0 +1,11 @@
+{
+  "name" : "gist-vim",
+  "version" : "7.3",
+  "author" : "Yasuhiro Matsumoto <mattn.jp@gmail.com>",
+  "maintainer" : "Yasuhiro Matsumoto <mattn.jp@gmail.com>",
+  "repository" : {"type": "git", "url": "git://github.com/mattn/gist-vim.git"},
+  "dependencies" : {
+    "WebAPI": {}
+  },
+  "description" : "vimscript for gist"
+}


### PR DESCRIPTION
The `addon-info.json` is used by [VAM](https://github.com/MarcWeber/vim-addon-manager) to determine the dependencies among other things. VAM is used by Nix, and it was not able to infer the dependencies as is, see it [here](https://github.com/NixOS/nixpkgs/blob/ee57cb3a2479d894ca407d32217bd4988482bf66/pkgs/misc/vim-plugins/default.nix#L1859-L1868)

For full context, see my PR over on [nixpkgs](https://github.com/NixOS/nixpkgs/pull/43399).